### PR TITLE
fix: exception catch when no commit on that day

### DIFF
--- a/gitlab-contrib-migrator.py
+++ b/gitlab-contrib-migrator.py
@@ -20,7 +20,10 @@ def parseHTMLAndCreateCommits(htmlContents, startDate):
     print("Starting commits!\n")
     for dateRect in tqdm(dateRects):
         contribsAndDate = dateRect["data-original-title"].split("<br />")
-        contribCount = int(contribsAndDate[0].split(" ")[0])
+           try:
+            contribCount = int(contribsAndDate[0].split(" ")[0])
+        except ValueError:
+            continue;
         date = datetime.strptime(contribsAndDate[1], '%A %b %d, %Y')
         if startDate == -1 or startDate <= date:
             createNumOfCommitsOnDate(contribCount, date)


### PR DESCRIPTION
It throw exceptions on cast to int when running this script with an account that doesn't commit daily.